### PR TITLE
Update README for portfolio site structure and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,84 @@
-# Astro Starter Kit: Basics
+# Portfolio Site
 
-```sh
-npm create astro@latest -- --template basics
-```
+Astro で構築したポートフォリオサイトです。プロフィール、経歴、技術スタック、記事一覧などを表示できる構成になっています。
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
-## 🚀 Project Structure
+## 構成
 
-Inside of your Astro project, you'll see the following folders and files:
+このリポジトリは、ポートフォリオサイトを構築するための実用的なテンプレート兼実装例です。主な構成を表にまとめます。
+
+| 項目 | 内容 |
+| --- | --- |
+| ページ構成 | `src/pages` にトップページなどの静的ページを配置。各ページは Astro コンポーネントで構成し、必要であれば部分的に React を組み合わせます。 |
+| レイアウト | `src/layouts/Layout.astro` で共通ヘッダー／フッター／メタ情報（SEO）を管理。ページ間で一貫した UI を提供します。 |
+| コンポーネント分割 | `src/components` を機能別に分割（プロフィール、記事一覧、職歴、技術スタックなど）。再利用性を優先した設計です。 |
+| データ取得 | `src/lib/zenn.ts` に Zenn 記事取得ロジックを実装。ビルド時やサーバーサイドで外部データを取得して静的ページに組み込みます。 |
+| アナリティクス | `src/components/common/GoogleAnalytics.astro` で Partytown 経由の Google Analytics を設定し、メインスレッド負荷を低減します。 |
+| スタイル | Tailwind CSS を採用。`src/styles/global.css` に基本設定を置き、ユーティリティクラスでレスポンシブ対応します。 |
+| 画像・公開資産 | `public/images` にアセットを格納。CNAME 等のデプロイ関連ファイルも `public` 配下に配置。 |
+| ビルドとデプロイ | Astro のビルド出力を静的ホスティング（Vercel / Netlify / GitHub Pages 等）へデプロイする想定。`package.json` にスクリプトあり。 |
+
+
+## プロジェクト構成
 
 ```text
 /
 ├── public/
-│   └── favicon.svg
-├── src
-│   ├── assets
-│   │   └── astro.svg
-│   ├── components
-│   │   └── Welcome.astro
-│   ├── layouts
-│   │   └── Layout.astro
-│   └── pages
-│       └── index.astro
-└── package.json
+│   ├── CNAME
+│   └── images/
+├── src/
+│   ├── components/
+│   │   ├── Profile.astro
+│   │   ├── articles/
+│   │   ├── careers/
+│   │   ├── common/
+│   │   └── profile/
+│   ├── layouts/
+│   │   └── Layout.astro
+│   ├── lib/
+│   │   └── zenn.ts
+│   ├── pages/
+│   │   └── index.astro
+│   └── styles/
+│       └── global.css
+├── astro.config.mjs
+├── package.json
+└── tsconfig.json
 ```
 
-To learn more about the folder structure of an Astro project, refer to [our guide on project structure](https://docs.astro.build/en/basics/project-structure/).
+## 開発コマンド
 
-## 🧞 Commands
+ルートディレクトリで以下のコマンドを実行します。
 
-All commands are run from the root of the project, from a terminal:
+```bash
+npm install
+npm run dev
+```
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+### その他
 
-## 👀 Want to learn more?
+```bash
+npm run build
+npm run preview
+npm run astro -- --help
+```
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+
+## 技術スタック
+
+以下は本プロジェクトで採用している主要な技術を表でまとめたものです。
+
+| 技術 | 役割 | 備考 |
+| --- | --- | --- |
+| Astro | 静的サイト生成（SSG）と部分的なクライアントレンダリング（Islands Architecture） | Vite ベースの開発環境／ビルドを提供 |
+| React | インタラクティブな UI 部分で使用（必要箇所のみ） | Astro と組み合わせて部分的にクライアントサイドレンダリングを行う |
+| Tailwind CSS | ユーティリティファーストのスタイリング | `src/styles/global.css` に基本設定とカスタムユーティリティを配置 |
+| Partytown + Google Analytics | サードパーティスクリプトをワーカーへ移動し、メインスレッド負荷を低減 | `src/components/common/GoogleAnalytics.astro` で設定 |
+| Day.js | 日付のフォーマット・表示 | 軽量でシンプルな日付処理ライブラリ |
+| RSS Parser / Zenn API ラッパー | Zenn の記事や RSS を取得して静的ページに組み込む | 実装は `src/lib/zenn.ts` に集約 |
+| TypeScript | 型安全性の確保、開発時の信頼性向上 | `tsconfig.json` を利用 |
+| Vite（Astro ビルド） | 開発サーバーと高速ビルド／バンドリング | 最適化された静的出力を生成 |
+| SEO / アクセシビリティ | メタタグ／構造化データ／アクセシビリティ配慮 | 各ページで実装、クローラビリティ向上を目的 |
+| デプロイ / CI | 静的ホスティング（Vercel / Netlify / GitHub Pages）で公開 | CI でビルド→デプロイの自動化を想定 |
+
+必要ならバージョンや導入方法、スニペットを README に追記できます。


### PR DESCRIPTION
This pull request updates the `README.md` to provide a comprehensive and practical guide for the portfolio site built with Astro. The new documentation replaces the default Astro starter instructions with detailed information on the project structure, setup commands, and the technologies used. This makes it much easier for developers to understand the purpose, setup, and architecture of the repository.

**Documentation overhaul:**

* Replaced the Astro starter kit instructions with a project-specific introduction, explaining the purpose and features of the portfolio site.
* Added a detailed table summarizing the main components and structure of the repository, including pages, layouts, components, data fetching, analytics, styles, assets, and deployment.
* Expanded the project structure section with an updated directory tree reflecting the actual files and folders in the repository.

**Developer experience improvements:**

* Documented the main development commands (`npm install`, `npm run dev`, etc.) and included additional useful scripts for building and previewing the site.
* Added a technology stack table, listing the key technologies used in the project (Astro, React, Tailwind CSS, Partytown, Day.js, etc.), their roles, and related notes for easy reference.